### PR TITLE
dont_blame_nrpe not working properly

### DIFF
--- a/nrpe_ng/commands.py
+++ b/nrpe_ng/commands.py
@@ -79,7 +79,8 @@ class Command:
                 continue
 
             var = mo.group('arg')
-            run_args.append(args.get(var, ''))
+            new_arg = re.sub(r'\$'+var+r'\$', args.get(var, ''), arg)
+            run_args.append(new_arg)
 
         log.debug('Executing: {}'.format(subprocess.list2cmdline(run_args)))
 


### PR DESCRIPTION
If you had a server command of `command[check_custom]=/bin/se$ARG1$ $ARG2$ $ARG3$`

And tried to run `check_nrpe_ng ... -c check_custom -a q 1 2` what you would expect is an attempt to run `/bin/seq 1 2` as was done with original nrpe. With nrpe-ng, it was trying to just run `q 1 2`

This patch corrects this issue.